### PR TITLE
Added pause + extend recording

### DIFF
--- a/index.js
+++ b/index.js
@@ -256,6 +256,20 @@ instance.prototype.actions = function(system) {
 					id: 'stop_rec',
 			}]
 		}
+		'pause_rec': {
+			label: 'Pause recording',
+			options: [{
+					label: 'Pause recording',
+					id: 'pause_rec',
+			}]
+		}
+		'extend_rec': {
+			label: 'Extend recording 5min',
+			options: [{
+					label: 'Extend recording 5min',
+					id: 'extend_rec',
+			}]
+		}
 	};
 
 	self.setActions(actions);
@@ -291,6 +305,14 @@ instance.prototype.action = function(action) {
 
 		case 'stop_rec':
 			cmd = "\x1BY0RCDR";
+			break;
+		
+		case 'pause_rec':
+			cmd = "\x1BY2RCDR";
+			break;
+		
+		case 'extend_rec':
+			cmd = "\x1BE35RCDR";
 			break;
 
 	}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 	],
 	"manufacturer": "Extron",
 	"product": "SMP 351",
-	"shortname": "SMP",
+	"shortname": "SMP 351",
 	"description": "SMP 351 plugin for Companion",
 	"main": "index.js",
 	"scripts": {


### PR DESCRIPTION
Added command for pausing an ongoing recording
Added command for extending a recording for a default duration of 5min (https://github.com/bitfocus/companion-module-extron-smp351/issues/3)