### PR TITLE
Add support for composite layout presets in dual mode

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -21,6 +21,7 @@
 
 - **Record state** Stop/Record/Pause
 - **Stream Primary/Backup state** On/Off
+- **Dual Encoder mode** On/Off
 
 ## Supported button variables
 


### PR DESCRIPTION
This commit adds a feedback for the encoder mode, to differentiate between composite and dual channel encoder mode, and adds an action 'layoutPresetDual' to allow changing the layout of the confidence stream in dual channel mode.